### PR TITLE
Handle early onset services

### DIFF
--- a/priv/repo/migrations/20170412103732_add_early_onset_field.exs
+++ b/priv/repo/migrations/20170412103732_add_early_onset_field.exs
@@ -1,0 +1,10 @@
+defmodule What3things.Repo.Migrations.AddEarlyOnsetField do
+  use Ecto.Migration
+
+  def change do
+    alter table(:services) do
+      add :early_onset, :boolean, default: false
+    end
+
+  end
+end

--- a/test/elm/TestHelpers.elm
+++ b/test/elm/TestHelpers.elm
@@ -13,7 +13,7 @@ dummyWeightings =
 
 dummyServiceData : ServiceData
 dummyServiceData =
-    ServiceData "" "" "" ""
+    ServiceData "" "" "" "" False
 
 
 servicesDict : Services

--- a/web/controllers/service_controller.ex
+++ b/web/controllers/service_controller.ex
@@ -6,4 +6,11 @@ defmodule What3things.ServiceController do
     services = Repo.all(Service)
     render conn, "index.html", services: services
   end
+
+  def edit(conn, %{"id" => service_id}) do
+    service = Repo.get(Service, service_id)
+    changeset = Service.changeset(service)
+
+    render conn, "edit.html", changeset: changeset, service: service
+  end
 end

--- a/web/controllers/service_controller.ex
+++ b/web/controllers/service_controller.ex
@@ -13,4 +13,18 @@ defmodule What3things.ServiceController do
 
     render conn, "edit.html", changeset: changeset, service: service
   end
+
+  def update(conn, %{"id" => service_id, "service" => service}) do
+    old_service = Repo.get(Service, service_id)
+    changeset = Service.changeset(old_service, service)
+
+    case Repo.update(changeset) do
+      {:ok, _service} ->
+        conn
+        |> put_flash(:info, "service updated")
+        |> redirect(to: service_path(conn, :index))
+      {:error, changeset} ->
+        render conn, "edit.html", changeset: changeset, service: old_service
+    end
+  end
 end

--- a/web/elm/Data/Services.elm
+++ b/web/elm/Data/Services.elm
@@ -30,4 +30,4 @@ top3things userWeightings services =
 
 nullServiceData : ServiceData
 nullServiceData =
-    ServiceData "" "" "" ""
+    ServiceData "" "" "" "" False

--- a/web/elm/Data/Shuffle.elm
+++ b/web/elm/Data/Shuffle.elm
@@ -1,0 +1,41 @@
+module Data.Shuffle exposing (..)
+
+import Random exposing (..)
+import Model exposing (..)
+import Tuple exposing (..)
+
+
+handleShuffleQuotes : List QuoteId -> List Int -> Model -> Model
+handleShuffleQuotes qIds randomInts model =
+    let
+        shuffledIds =
+            shuffleList qIds randomInts
+    in
+        { model
+            | currentQuote = List.head shuffledIds
+            , remainingQuotes = List.tail shuffledIds
+        }
+
+
+shuffleQuoteIds : List QuoteId -> Cmd Msg
+shuffleQuoteIds qIds =
+    generate (ShuffleQuoteIds qIds) (randomList qIds)
+
+
+shuffleList : List Int -> List Int -> List Int
+shuffleList xs randomXs =
+    xs
+        |> List.map2 (,) randomXs
+        |> List.sortBy first
+        |> List.unzip
+        |> second
+
+
+randomList : List QuoteId -> Generator (List Int)
+randomList qIds =
+    list (List.length qIds) randomInt
+
+
+randomInt : Generator Int
+randomInt =
+    int 0 100

--- a/web/elm/Data/Web/QuoteServiceWeighting.elm
+++ b/web/elm/Data/Web/QuoteServiceWeighting.elm
@@ -41,12 +41,13 @@ servicesDecoder =
 
 rawServiceDecoder : Decoder ( ServiceId, ServiceData )
 rawServiceDecoder =
-    decode (\serviceId body title cta url -> ( serviceId, ServiceData title body cta url ))
+    decode (\serviceId body title cta url earlyOnset -> ( serviceId, ServiceData title body cta url earlyOnset ))
         |> required "id" int
         |> required "body" string
         |> required "title" string
         |> required "cta" string
         |> required "url" string
+        |> required "early_onset" bool
 
 
 weightingDecoder : Decoder Weightings

--- a/web/elm/Data/Web/QuoteServiceWeightings.elm
+++ b/web/elm/Data/Web/QuoteServiceWeightings.elm
@@ -1,4 +1,4 @@
-module Data.Web.QuoteServiceWeighting exposing (..)
+module Data.Web.QuoteServiceWeightings exposing (..)
 
 import Json.Decode exposing (..)
 import Json.Decode.Pipeline exposing (..)
@@ -8,15 +8,15 @@ import Dict exposing (..)
 import Set
 
 
-getQuoteServiceWeighting : Cmd Msg
-getQuoteServiceWeighting =
-    Http.get "/api/all" quoteServiceWeightingDecoder
-        |> Http.send ReceiveQuoteServiceWeighting
+getQuoteServiceWeightings : Cmd Msg
+getQuoteServiceWeightings =
+    Http.get "/api/all" quoteServiceWeightingsDecoder
+        |> Http.send ReceiveQuoteServiceWeightings
 
 
-quoteServiceWeightingDecoder : Decoder QuoteServiceWeighting
-quoteServiceWeightingDecoder =
-    decode QuoteServiceWeighting
+quoteServiceWeightingsDecoder : Decoder QuoteServiceWeightings
+quoteServiceWeightingsDecoder =
+    decode QuoteServiceWeightings
         |> required "quotes" quoteDecoder
         |> required "services" servicesDecoder
         |> required "weightings" weightingDecoder

--- a/web/elm/Data/Weightings.elm
+++ b/web/elm/Data/Weightings.elm
@@ -4,6 +4,14 @@ import Model exposing (..)
 import Dict exposing (..)
 
 
+getEarlyOnsetIds : Services -> List ServiceId
+getEarlyOnsetIds services =
+    services
+        |> Dict.toList
+        |> List.filter (\( sid, { earlyOnset } ) -> earlyOnset)
+        |> List.map Tuple.first
+
+
 updateWeightings : Answer -> Model -> Model
 updateWeightings answer model =
     let

--- a/web/elm/Data/Weightings.elm
+++ b/web/elm/Data/Weightings.elm
@@ -4,6 +4,28 @@ import Model exposing (..)
 import Dict exposing (..)
 
 
+handleEarlyOnsetWeightings : QuoteServiceWeightings -> Weightings
+handleEarlyOnsetWeightings quoteServiceWeightings =
+    let
+        serviceIds =
+            getEarlyOnsetIds quoteServiceWeightings.services
+    in
+        alterWeightings serviceIds quoteServiceWeightings.weightings
+
+
+alterWeightings : List ServiceId -> Weightings -> Weightings
+alterWeightings serviceIds weightings =
+    let
+        alterWeight sId weight =
+            if List.member sId serviceIds then
+                weight * 3
+            else
+                weight
+    in
+        weightings
+            |> Dict.map (\_ weightingsDict -> Dict.map alterWeight weightingsDict)
+
+
 getEarlyOnsetIds : Services -> List ServiceId
 getEarlyOnsetIds services =
     services
@@ -16,7 +38,7 @@ updateWeightings : Answer -> Model -> Model
 updateWeightings answer model =
     let
         newWeightings =
-            addWeightings model.userWeightings (getWeightingsById model.currentQuote model.weightings)
+            addWeightings model.userWeightings (getWeightingsById model.currentQuote <| relevantWeightings model)
     in
         case answer of
             Yes ->
@@ -36,6 +58,16 @@ getWeightingsById qId weightings =
 
         Nothing ->
             Dict.empty
+
+
+relevantWeightings : Model -> Weightings
+relevantWeightings model =
+    case model.ageRange of
+        Just UnderForty ->
+            model.earlyOnsetWeightings
+
+        _ ->
+            model.weightings
 
 
 makeEmptyWeightingsDict : Services -> WeightingsDict

--- a/web/elm/Data/Weightings.elm
+++ b/web/elm/Data/Weightings.elm
@@ -62,12 +62,23 @@ getWeightingsById qId weightings =
 
 relevantWeightings : Model -> Weightings
 relevantWeightings model =
+    if shouldReceiveEarlyOnsetWeightings model then
+        model.earlyOnsetWeightings
+    else
+        model.weightings
+
+
+shouldReceiveEarlyOnsetWeightings : Model -> Bool
+shouldReceiveEarlyOnsetWeightings model =
     case model.ageRange of
         Just UnderForty ->
-            model.earlyOnsetWeightings
+            True
+
+        Just Forties ->
+            True
 
         _ ->
-            model.weightings
+            False
 
 
 makeEmptyWeightingsDict : Services -> WeightingsDict

--- a/web/elm/Model.elm
+++ b/web/elm/Model.elm
@@ -107,6 +107,7 @@ type Msg
     | SetAgeRange AgeRange
     | SetEmail String
     | ReceiveQuoteServiceWeightings (Result Http.Error QuoteServiceWeightings)
+    | ShuffleQuoteIds (List QuoteId) (List Int)
     | SubmitAnswer Answer
     | HandleGoToQuotes
     | ReceiveUserId (Result Http.Error Int)

--- a/web/elm/Model.elm
+++ b/web/elm/Model.elm
@@ -65,6 +65,7 @@ type alias ServiceData =
     , body : String
     , cta : String
     , url : String
+    , earlyOnset : Bool
     }
 
 

--- a/web/elm/Model.elm
+++ b/web/elm/Model.elm
@@ -15,6 +15,7 @@ type alias Model =
     , services : Services
     , top3things : List ServiceData
     , weightings : Weightings
+    , earlyOnsetWeightings : Weightings
     , fetchErrorMessage : String
     , currentQuote : Maybe QuoteId
     , remainingQuotes : Maybe (List QuoteId)
@@ -92,7 +93,7 @@ type alias ServiceId =
     Int
 
 
-type alias QuoteServiceWeighting =
+type alias QuoteServiceWeightings =
     { quotes : Quotes
     , services : Services
     , weightings : Weightings
@@ -105,7 +106,7 @@ type Msg
     | SetPostcode String
     | SetAgeRange AgeRange
     | SetEmail String
-    | ReceiveQuoteServiceWeighting (Result Http.Error QuoteServiceWeighting)
+    | ReceiveQuoteServiceWeightings (Result Http.Error QuoteServiceWeightings)
     | SubmitAnswer Answer
     | HandleGoToQuotes
     | ReceiveUserId (Result Http.Error Int)

--- a/web/elm/Update.elm
+++ b/web/elm/Update.elm
@@ -2,7 +2,7 @@ module Update exposing (..)
 
 import Model exposing (..)
 import Data.UserInfo exposing (validatePostcode)
-import Data.Web.QuoteServiceWeighting exposing (getQuoteServiceWeighting)
+import Data.Web.QuoteServiceWeightings exposing (getQuoteServiceWeightings)
 import Data.Web.Answers exposing (handlePostAnswers)
 import Data.Web.User exposing (..)
 import Data.Web.UserEmail exposing (..)
@@ -14,7 +14,7 @@ import Dict
 
 init : ( Model, Cmd Msg )
 init =
-    initialModel ! [ getQuoteServiceWeighting ]
+    initialModel ! [ getQuoteServiceWeightings ]
 
 
 initialModel : Model
@@ -29,6 +29,7 @@ initialModel =
     , services = Dict.empty
     , top3things = []
     , weightings = Dict.empty
+    , earlyOnsetWeightings = Dict.empty
     , fetchErrorMessage = ""
     , currentQuote = Nothing
     , remainingQuotes = Nothing
@@ -55,10 +56,10 @@ update msg model =
         SetEmail email ->
             { model | email = Just email } ! []
 
-        ReceiveQuoteServiceWeighting (Err _) ->
+        ReceiveQuoteServiceWeightings (Err _) ->
             { model | fetchErrorMessage = "Something went wrong fetching the data." } ! []
 
-        ReceiveQuoteServiceWeighting (Ok data) ->
+        ReceiveQuoteServiceWeightings (Ok data) ->
             let
                 qIds =
                     getQuoteIds data.quotes
@@ -67,6 +68,7 @@ update msg model =
                     | quotes = data.quotes
                     , services = data.services
                     , weightings = data.weightings
+                    , earlyOnsetWeightings = handleEarlyOnsetWeightings data
                     , remainingQuotes = List.tail qIds
                     , currentQuote = List.head qIds
                     , userWeightings = makeEmptyWeightingsDict data.services

--- a/web/elm/Views/Services.elm
+++ b/web/elm/Views/Services.elm
@@ -16,7 +16,7 @@ services model =
         , div [ class "bg-blue pb6" ] (List.map renderService model.top3things)
         , div [ class "mw7 center mv4" ]
             [ h3 [ class "blue" ] [ text "If you'd like a copy of your results for futute reference, please enter your email" ]
-            , input [ onInput SetEmail, class (Styles.inputField ++ " mw5 center"), placeholder "put your email" ] []
+            , input [ onInput SetEmail, class (Styles.inputField ++ " mw5 center"), placeholder "put your email", value <| Maybe.withDefault "" model.email ] []
             , button [ onClick SubmitEmail, class (Styles.buttonBlue ++ " mt3") ] [ text "submit" ]
             ]
         ]

--- a/web/elm/Views/Services.elm
+++ b/web/elm/Views/Services.elm
@@ -12,7 +12,7 @@ services : Model -> Html Msg
 services model =
     div []
         [ logo
-        , h2 [ class "blue mb4" ] [ text <| renderName model ]
+        , h2 [ class "blue mb4" ] [ text "Here you are, your tailored list of Parkinson's services" ]
         , div [ class "bg-blue pb6" ] (List.map renderService model.top3things)
         , div [ class "mw7 center mv4" ]
             [ h3 [ class "blue" ] [ text "If you'd like a copy of your results for futute reference, please enter your email" ]
@@ -20,20 +20,6 @@ services model =
             , button [ onClick SubmitEmail, class (Styles.buttonBlue ++ " mt3") ] [ text "submit" ]
             ]
         ]
-
-
-renderName : Model -> String
-renderName model =
-    let
-        title name =
-            "Here you are" ++ name ++ ", your tailored list of Parkinson's servivces"
-    in
-        case model.name of
-            Just name ->
-                title <| " " ++ name
-
-            Nothing ->
-                title ""
 
 
 renderService : ServiceData -> Html Msg

--- a/web/models/service.ex
+++ b/web/models/service.ex
@@ -1,7 +1,7 @@
 defmodule What3things.Service do
   use What3things.Web, :model
 
-  @derive{Poison.Encoder, only: [:title, :body, :id, :cta, :url]}
+  @derive{Poison.Encoder, only: [:title, :body, :id, :cta, :url, :early_onset]}
   schema "services" do
     field :title, :string
     field :body, :string

--- a/web/models/service.ex
+++ b/web/models/service.ex
@@ -7,12 +7,16 @@ defmodule What3things.Service do
     field :body, :string
     field :cta, :string
     field :url, :string
+    field :early_onset, :boolean
   end
+
+  @valid_fields [:title, :body, :cta, :url, :early_onset]
+  @required_fields [:title, :body, :cta, :url, :early_onset]
 
   def changeset(struct, params \\ %{}) do
     struct
-    |> cast(params, [:title, :body, :cta, :url])
-    |> validate_required([:title, :body, :cta, :url])
+    |> cast(params, @valid_fields)
+    |> validate_required(@required_fields)
   end
 
 end

--- a/web/models/weight.ex
+++ b/web/models/weight.ex
@@ -8,9 +8,12 @@ defmodule What3things.Weight do
     belongs_to :service, What3things.Service
   end
 
+  @service_quote_error_message "Must be a unique service-quote pair"
+
   def changeset(struct, params \\ %{}) do
     struct
     |> cast(params, [:weight, :quote_id, :service_id])
+    |> unique_constraint(:unique_service_quote_pair, name: :weights_quote_id_service_id_index, message: @service_quote_error_message)
     |> validate_required([:quote_id, :service_id, :weight])
   end
 end

--- a/web/router.ex
+++ b/web/router.ex
@@ -29,7 +29,7 @@ defmodule What3things.Router do
 
     get "/", AdminController, :index
     resources "/quotes", QuoteController, only: [:index]
-    resources "/services", ServiceController, only: [:index]
+    resources "/services", ServiceController, only: [:index, :edit, :update]
     resources "/weights", WeightController, only: [:index, :edit, :update]
   end
 

--- a/web/templates/service/edit.html.eex
+++ b/web/templates/service/edit.html.eex
@@ -2,5 +2,25 @@
 <h1 class="orange">Edit Service</h1>
 <%= form_for @changeset, service_path(@conn, :update, @service), fn f -> %>
   <h5 class="blue">Title</h5>
-  <%= text_input f, :title, placeholder: "Service title" %>
+  <p class="red"><%= error_tag f, :title %></p>
+  <%= text_input f, :title, placeholder: "Service title", class: "w6" %>
+
+  <h5 class="blue">Body</h5>
+  <p class="red"><%= error_tag f, :body %></p>
+  <%= textarea f, :body, placeholder: "service body", class: "w7 h4" %>
+
+  <h5 class="blue">Call to action</h5>
+  <p class="red"><%= error_tag f, :cta %></p>
+  <%= text_input f, :cta, placeholder: "call to action", class: "w6" %>
+
+  <h5 class="blue">Link to service</h5>
+  <p class="red"><%= error_tag f, :url %></p>
+  <%= text_input f, :url, placeholder: "link to service", class: "w6" %>
+
+  <div>
+    <h5 class="blue dib">Is early onset</h5>
+    <%= checkbox f, :early_onset, class: "dib" %>
+  </div>
+
+  <%= submit "Edit service" %>
 <% end %>

--- a/web/templates/service/edit.html.eex
+++ b/web/templates/service/edit.html.eex
@@ -1,0 +1,6 @@
+<%= link "back to services", to: service_path(@conn, :index), class: "no-underline blue" %>
+<h1 class="orange">Edit Service</h1>
+<%= form_for @changeset, service_path(@conn, :update, @service), fn f -> %>
+  <h5 class="blue">Title</h5>
+  <%= text_input f, :title, placeholder: "Service title" %>
+<% end %>

--- a/web/templates/service/index.html.eex
+++ b/web/templates/service/index.html.eex
@@ -6,6 +6,9 @@
   <%= for service <- @services do %>
   <li>
     <%= service.title %>
+    <%= link to: service_path(@conn, :edit, service) do %>
+      <p>Edit</p>
+    <% end %>
   </li>
   <% end %>
 </ul>

--- a/web/templates/service/index.html.eex
+++ b/web/templates/service/index.html.eex
@@ -3,12 +3,11 @@
 <h1 class="tc">Services</h1>
 
 <ul>
-  <%= for service <- @services do %>
-  <li>
-    <%= service.title %>
-    <%= link to: service_path(@conn, :edit, service) do %>
-      <p>Edit</p>
-    <% end %>
-  </li>
+  <%= for service <- order_services(@services) do %>
+    <li>
+      <div class="">
+        <%= service.title %> -- <%= link "Edit", to: service_path(@conn, :edit, service) %>
+      </div>
+    </li>
   <% end %>
 </ul>

--- a/web/templates/weight/index.html.eex
+++ b/web/templates/weight/index.html.eex
@@ -9,7 +9,7 @@
     <table class="mb5">
       <tr>
         <%= for w <- weight do %>
-          <th class="blue pb3" style="font-size: 0.75rem">
+          <th class="blue pa3" style="font-size: 0.75rem">
             <%= w.service.title %>
           </th>
         <% end %>

--- a/web/views/service_view.ex
+++ b/web/views/service_view.ex
@@ -1,3 +1,8 @@
 defmodule What3things.ServiceView do
   use What3things.Web, :view
+
+  def order_services(services) do
+    services
+    |> Enum.sort_by(fn(x) -> x.id end)
+  end
 end


### PR DESCRIPTION
* Add `early_onset` column to services table.
* Add admin interface for updating services.
* Handle `early_onset` data in Elm decoder.
* Increase weighting for 'early onset' services if user is in 40s or under.
* Add error for Weight changeset if unique service-quote pair is violated.

Resolves #50 
Resolves #52 
Resolves #51
Resolves #68 