### PR TITLE
normalise data being sent to server

### DIFF
--- a/web/controllers/elm_controller.ex
+++ b/web/controllers/elm_controller.ex
@@ -6,7 +6,7 @@ defmodule What3things.ElmController do
     render conn, "index.html"
   end
 
-  def all(conn, _params) do
+  def quotes_services_weightings(conn, _params) do
     quotes = Repo.all(Quote)
     services = Repo.all(Service)
     weightings = Repo.all(Weight)

--- a/web/elm/Data/Web/Normalise.elm
+++ b/web/elm/Data/Web/Normalise.elm
@@ -1,0 +1,42 @@
+module Data.Web.Normalise exposing (..)
+
+import Model exposing (..)
+
+
+normaliseName : String -> String
+normaliseName =
+    String.toLower
+
+
+normaliseEmail : String -> String
+normaliseEmail =
+    String.toLower
+
+
+normalisePostcode : String -> String
+normalisePostcode postcode =
+    postcode
+        |> String.filter ((/=) ' ')
+        |> String.toLower
+
+
+normaliseAgeRange : AgeRange -> String
+normaliseAgeRange ageRange =
+    case ageRange of
+        UnderForty ->
+            "under_forty"
+
+        Forties ->
+            "forties"
+
+        Fifties ->
+            "fifties"
+
+        Sixties ->
+            "sixties"
+
+        Seventies ->
+            "seventies"
+
+        OverEighty ->
+            "over_eighty"

--- a/web/elm/Data/Web/QuoteServiceWeightings.elm
+++ b/web/elm/Data/Web/QuoteServiceWeightings.elm
@@ -10,7 +10,7 @@ import Set
 
 getQuoteServiceWeightings : Cmd Msg
 getQuoteServiceWeightings =
-    Http.get "/api/all" quoteServiceWeightingsDecoder
+    Http.get "/api/quotes-services-weightings" quoteServiceWeightingsDecoder
         |> Http.send ReceiveQuoteServiceWeightings
 
 

--- a/web/elm/Data/Web/User.elm
+++ b/web/elm/Data/Web/User.elm
@@ -5,6 +5,7 @@ import Http exposing (..)
 import Json.Encode as Encode
 import Json.Decode as Decode exposing (..)
 import Data.UserInfo exposing (..)
+import Data.Web.Normalise exposing (..)
 
 
 postUserDetails : Model -> Cmd Msg
@@ -34,17 +35,19 @@ makeUserDetailsJson model =
 encodeName : Model -> String
 encodeName model =
     Maybe.withDefault "" model.name
+        |> normaliseName
 
 
 encodeAgeRange : Model -> String
 encodeAgeRange model =
     Maybe.withDefault UnderForty model.ageRange
-        |> ageRangeToString
+        |> normaliseAgeRange
 
 
 encodePostcode : Model -> String
 encodePostcode model =
     postCodeToString model.postcode
+        |> normalisePostcode
 
 
 userIdDecoder : Decoder Int

--- a/web/elm/Data/Web/UserEmail.elm
+++ b/web/elm/Data/Web/UserEmail.elm
@@ -3,6 +3,7 @@ module Data.Web.UserEmail exposing (..)
 import Model exposing (..)
 import Json.Encode as Encode exposing (..)
 import Http exposing (..)
+import Data.Web.Normalise exposing (normaliseEmail)
 
 
 sendUserEmail : Model -> Cmd Msg
@@ -23,12 +24,14 @@ makeUserJson model =
 
 makeEmailJson : Model -> Encode.Value
 makeEmailJson model =
-    let
-        email =
-            Maybe.withDefault "" model.email
-    in
-        Encode.object
-            [ ( "email", Encode.string email ) ]
+    Encode.object
+        [ ( "email", Encode.string <| encodeEmail model ) ]
+
+
+encodeEmail : Model -> String
+encodeEmail model =
+    Maybe.withDefault "" model.email
+        |> normaliseEmail
 
 
 put : String -> Http.Body -> Request ()

--- a/web/router.ex
+++ b/web/router.ex
@@ -37,7 +37,7 @@ defmodule What3things.Router do
   scope "/api", What3things do
     pipe_through :api
 
-    get "/all", ElmController, :all
+    get "/quotes-services-weightings", ElmController, :quotes_services_weightings
 
     resources "/users", UserController, except: [:new, :edit, :delete] do
       resources "/answers", AnswerController, except: [:new, :edit, :delete]


### PR DESCRIPTION
Change ‘/all’ api route to ‘quotes-services-weightings’ and normalise user details being sent to server

resolves #74