### PR TITLE
Display url and validate email

### DIFF
--- a/test/elm/UserInfoSpec.elm
+++ b/test/elm/UserInfoSpec.elm
@@ -28,27 +28,27 @@ valdidatePostcodeSpec =
         [ describe "validatePostcode"
             [ test "an empty postcode should return a NotEntered Value" <|
                 \() ->
-                    Expect.equal (validatePostcode "") NotEntered
+                    Expect.equal (validatePostcode "") NotEnteredPostcode
             , test "an invalid postcode should return the postcode wrapped in an Invalid value" <|
                 \() ->
-                    Expect.equal (validatePostcode "e83") (Invalid "e83")
+                    Expect.equal (validatePostcode "e83") (InvalidPostcode "e83")
             , test "a valid postcode should return the postcoed wrapped in a Valid value" <|
                 \() ->
-                    Expect.equal (validatePostcode "e82na") (Valid "e82na")
+                    Expect.equal (validatePostcode "e82na") (ValidPostcode "e82na")
             , test "should handle capital letters" <|
                 \() ->
-                    Expect.equal (validatePostcode "E82NA") (Valid "E82NA")
+                    Expect.equal (validatePostcode "E82NA") (ValidPostcode "E82NA")
             ]
         , describe "isValidPostcode"
             [ test "returns True for a Valid Postcode" <|
                 \() ->
-                    Expect.true "" (isValidPostcode validFormModel)
+                    Expect.true "" (isValidPostcode validFormModel.postcode)
             , test "returns False for an Invalid Postcode" <|
                 \() ->
-                    Expect.false "" (isValidPostcode invalidPostcodeModel)
+                    Expect.false "" (isValidPostcode invalidPostcodeModel.postcode)
             , test "returns False for a NotEntered Postcode" <|
                 \() ->
-                    Expect.false "" (isValidPostcode notEnteredPostcodeModel)
+                    Expect.false "" (isValidPostcode notEnteredPostcodeModel.postcode)
             ]
         ]
 
@@ -81,7 +81,7 @@ validFormModel : Model
 validFormModel =
     { initialModel
         | name = Just "andrew"
-        , postcode = Valid "e82na"
+        , postcode = ValidPostcode "e82na"
         , ageRange = Just UnderForty
     }
 
@@ -103,12 +103,12 @@ invalidAgeModel =
 invalidPostcodeModel : Model
 invalidPostcodeModel =
     { validFormModel
-        | postcode = Invalid "e82"
+        | postcode = InvalidPostcode "e82"
     }
 
 
 notEnteredPostcodeModel : Model
 notEnteredPostcodeModel =
     { validFormModel
-        | postcode = NotEntered
+        | postcode = NotEnteredPostcode
     }

--- a/web/elm/Data/UserInfo.elm
+++ b/web/elm/Data/UserInfo.elm
@@ -72,14 +72,11 @@ postcodeRegex =
 isValidPostcode : Model -> Bool
 isValidPostcode model =
     case model.postcode of
-        NotEnteredPostcode ->
-            False
-
-        InvalidPostcode _ ->
-            False
-
         ValidPostcode _ ->
             True
+
+        _ ->
+            False
 
 
 isValidName : Model -> Bool
@@ -100,3 +97,29 @@ isValidAgeRange model =
 
         Just _ ->
             True
+
+
+emailRegex : Regex
+emailRegex =
+    regex
+        "^(([^<>()\\[\\]\\\\.,;:\\s@\"]+(\\.[^<>()\\[\\]\\\\.,;:\\s@\"]+)*)|(\".+\"))@((\\[[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}])|(([a-zA-Z\\-0-9]+\\.)+[a-zA-Z]{2,}))$"
+
+
+validateEmail : String -> Email
+validateEmail email =
+    if Regex.contains emailRegex email then
+        ValidEmail email
+    else if email == "" then
+        NotEnteredEmail
+    else
+        InvalidEmail email
+
+
+isValidEmail : Model -> Bool
+isValidEmail model =
+    case model.email of
+        ValidEmail _ ->
+            True
+
+        _ ->
+            False

--- a/web/elm/Data/UserInfo.elm
+++ b/web/elm/Data/UserInfo.elm
@@ -40,24 +40,24 @@ ageRangeToString ageRange =
 postCodeToString : Postcode -> String
 postCodeToString postcode =
     case postcode of
-        NotEntered ->
+        NotEnteredPostcode ->
             ""
 
-        Invalid string ->
+        InvalidPostcode string ->
             string
 
-        Valid postcode ->
+        ValidPostcode postcode ->
             postcode
 
 
 validatePostcode : String -> Postcode
 validatePostcode postcode =
     if Regex.contains postcodeRegex postcode then
-        Valid postcode
+        ValidPostcode postcode
     else if postcode == "" then
-        NotEntered
+        NotEnteredPostcode
     else
-        Invalid postcode
+        InvalidPostcode postcode
 
 
 
@@ -72,13 +72,13 @@ postcodeRegex =
 isValidPostcode : Model -> Bool
 isValidPostcode model =
     case model.postcode of
-        NotEntered ->
+        NotEnteredPostcode ->
             False
 
-        Invalid _ ->
+        InvalidPostcode _ ->
             False
 
-        Valid _ ->
+        ValidPostcode _ ->
             True
 
 

--- a/web/elm/Data/UserInfo.elm
+++ b/web/elm/Data/UserInfo.elm
@@ -69,9 +69,9 @@ postcodeRegex =
     regex "^(([gG][iI][rR] {0,}0[aA]{2})|((([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y]?[0-9][0-9]?)|(([a-pr-uwyzA-PR-UWYZ][0-9][a-hjkstuwA-HJKSTUW])|([a-pr-uwyzA-PR-UWYZ][a-hk-yA-HK-Y][0-9][abehmnprv-yABEHMNPRV-Y]))) {0,}[0-9][abd-hjlnp-uw-zABD-HJLNP-UW-Z]{2}))$"
 
 
-isValidPostcode : Model -> Bool
-isValidPostcode model =
-    case model.postcode of
+isValidPostcode : Postcode -> Bool
+isValidPostcode postcode =
+    case postcode of
         ValidPostcode _ ->
             True
 
@@ -115,11 +115,30 @@ validateEmail email =
         InvalidEmail email
 
 
-isValidEmail : Model -> Bool
-isValidEmail model =
-    case model.email of
+isValidEmail : Email -> Bool
+isValidEmail email =
+    case email of
         ValidEmail _ ->
             True
 
         _ ->
             False
+
+
+emailToString : Email -> String
+emailToString email =
+    case email of
+        ValidEmail email ->
+            email
+
+        InvalidEmail email ->
+            email
+
+        RetrievedEmail email ->
+            email
+
+        SubmittedEmail email ->
+            email
+
+        _ ->
+            ""

--- a/web/elm/Data/Web/Answers.elm
+++ b/web/elm/Data/Web/Answers.elm
@@ -8,8 +8,8 @@ import Json.Decode as Decode exposing (..)
 
 handlePostAnswers : Model -> Cmd Msg
 handlePostAnswers model =
-    case model.view of
-        Services ->
+    case model.currentQuote of
+        Nothing ->
             postAnswers model
 
         _ ->
@@ -20,11 +20,16 @@ postAnswers : Model -> Cmd Msg
 postAnswers model =
     case model.userId of
         Just uId ->
-            Http.post ("/api/users/" ++ (toString uId) ++ "/answers") (Http.jsonBody <| makeAnswersJson model) (Decode.succeed ())
+            Http.post ("/api/users/" ++ (toString uId) ++ "/answers") (Http.jsonBody <| makeAnswersJson model) (answerResponseDecoder)
                 |> Http.send PostUserAnswers
 
         Nothing ->
             Cmd.none
+
+
+answerResponseDecoder : Decoder String
+answerResponseDecoder =
+    at [ "data", "uuid" ] string
 
 
 makeAnswersJson : Model -> Value

--- a/web/elm/Data/Web/Results/EntryPoint.elm
+++ b/web/elm/Data/Web/Results/EntryPoint.elm
@@ -47,8 +47,8 @@ repopulateUserData user model =
     { model
         | userId = Just user.id
         , name = Just user.name
-        , postcode = Valid user.postcode
-        , email = Just user.email
+        , postcode = ValidPostcode user.postcode
+        , email = RetrievedEmail user.email
         , ageRange = Just user.ageRange
     }
 

--- a/web/elm/Data/Web/Results/Request.elm
+++ b/web/elm/Data/Web/Results/Request.elm
@@ -24,6 +24,7 @@ previousResultsDecoder =
         |> required "quotes" quoteDecoder
         |> required "services" servicesDecoder
         |> required "weightings" weightingDecoder
+        |> requiredAt [ "answers", "uuid" ] string
 
 
 answersDecoder : Decoder (List ( QuoteId, Answer ))

--- a/web/elm/Data/Web/Results/Request.elm
+++ b/web/elm/Data/Web/Results/Request.elm
@@ -24,7 +24,6 @@ previousResultsDecoder =
         |> required "quotes" quoteDecoder
         |> required "services" servicesDecoder
         |> required "weightings" weightingDecoder
-        |> requiredAt [ "answers", "uuid" ] string
 
 
 answersDecoder : Decoder (List ( QuoteId, Answer ))

--- a/web/elm/Data/Web/UserEmail.elm
+++ b/web/elm/Data/Web/UserEmail.elm
@@ -4,6 +4,7 @@ import Model exposing (..)
 import Json.Encode as Encode exposing (..)
 import Http exposing (..)
 import Data.Web.Normalise exposing (normaliseEmail)
+import Data.UserInfo exposing (emailToString)
 
 
 sendUserEmail : Model -> Cmd Msg
@@ -30,24 +31,8 @@ makeEmailJson model =
 
 encodeEmail : Model -> String
 encodeEmail model =
-    emailToString model
+    emailToString model.email
         |> normaliseEmail
-
-
-emailToString : Model -> String
-emailToString model =
-    case model.email of
-        ValidEmail email ->
-            email
-
-        InvalidEmail email ->
-            email
-
-        RetrievedEmail email ->
-            email
-
-        _ ->
-            ""
 
 
 put : String -> Http.Body -> Request ()

--- a/web/elm/Data/Web/UserEmail.elm
+++ b/web/elm/Data/Web/UserEmail.elm
@@ -30,8 +30,24 @@ makeEmailJson model =
 
 encodeEmail : Model -> String
 encodeEmail model =
-    Maybe.withDefault "" model.email
+    emailToString model
         |> normaliseEmail
+
+
+emailToString : Model -> String
+emailToString model =
+    case model.email of
+        ValidEmail email ->
+            email
+
+        InvalidEmail email ->
+            email
+
+        RetrievedEmail email ->
+            email
+
+        _ ->
+            ""
 
 
 put : String -> Http.Body -> Request ()

--- a/web/elm/Model.elm
+++ b/web/elm/Model.elm
@@ -23,6 +23,7 @@ type alias Model =
     , userWeightings : WeightingsDict
     , userAnswers : List ( QuoteId, Answer )
     , entryPoint : EntryPoint
+    , uuid : Maybe String
     }
 
 
@@ -110,6 +111,7 @@ type alias Results =
     , quotes : Quotes
     , services : Services
     , weightings : Weightings
+    , uuid : String
     }
 
 
@@ -138,6 +140,6 @@ type Msg
     | ReceiveUserId (Result Http.Error Int)
     | PutUserEmail (Result Http.Error ())
     | SubmitEmail
-    | PostUserAnswers (Result Http.Error ())
+    | PostUserAnswers (Result Http.Error String)
     | UrlChange Navigation.Location
     | ReceiveResults (Result Http.Error Results)

--- a/web/elm/Model.elm
+++ b/web/elm/Model.elm
@@ -10,7 +10,7 @@ type alias Model =
     , name : Maybe String
     , postcode : Postcode
     , ageRange : Maybe AgeRange
-    , email : Maybe String
+    , email : Email
     , userId : Maybe Int
     , quotes : Quotes
     , services : Services
@@ -46,14 +46,22 @@ type AgeRange
 
 
 type Postcode
-    = NotEntered
-    | Valid String
-    | Invalid String
+    = NotEnteredPostcode
+    | ValidPostcode String
+    | InvalidPostcode String
 
 
 type Answer
     = Yes
     | No
+
+
+type Email
+    = NotEnteredEmail
+    | ValidEmail String
+    | InvalidEmail String
+    | RetrievedEmail String
+    | SubmittedEmail
 
 
 type alias Quotes =
@@ -111,7 +119,6 @@ type alias Results =
     , quotes : Quotes
     , services : Services
     , weightings : Weightings
-    , uuid : String
     }
 
 

--- a/web/elm/Model.elm
+++ b/web/elm/Model.elm
@@ -61,7 +61,7 @@ type Email
     | ValidEmail String
     | InvalidEmail String
     | RetrievedEmail String
-    | SubmittedEmail
+    | SubmittedEmail String
 
 
 type alias Quotes =

--- a/web/elm/Update.elm
+++ b/web/elm/Update.elm
@@ -44,6 +44,7 @@ initialModel =
     , userWeightings = Dict.empty
     , userAnswers = []
     , entryPoint = Start
+    , uuid = Nothing
     }
 
 
@@ -79,8 +80,6 @@ update msg model =
                 newModel =
                     model
                         |> handleAnswer answer
-                        |> handleGoToServices
-                        |> handleTop3Things
             in
                 newModel ! [ handlePostAnswers newModel ]
 
@@ -102,8 +101,17 @@ update msg model =
         SubmitEmail ->
             model ! [ sendUserEmail model ]
 
-        PostUserAnswers _ ->
+        PostUserAnswers (Err _) ->
             model ! []
+
+        PostUserAnswers (Ok uuid) ->
+            let
+                newModel =
+                    { model | uuid = Just uuid }
+                        |> handleGoToServices
+                        |> handleTop3Things
+            in
+                newModel ! []
 
         UrlChange location ->
             { model | entryPoint = setEntryPoint location } ! []

--- a/web/elm/Update.elm
+++ b/web/elm/Update.elm
@@ -29,9 +29,9 @@ initialModel : Model
 initialModel =
     { view = Home
     , name = Nothing
-    , postcode = NotEntered
+    , postcode = NotEnteredPostcode
     , ageRange = Nothing
-    , email = Nothing
+    , email = NotEnteredEmail
     , userId = Nothing
     , quotes = Dict.empty
     , services = Dict.empty
@@ -64,7 +64,7 @@ update msg model =
             { model | ageRange = Just ageRange } ! []
 
         SetEmail email ->
-            { model | email = Just email } ! []
+            { model | email = ValidEmail email } ! []
 
         ReceiveQuoteServiceWeightings (Err _) ->
             { model | fetchErrorMessage = "Something went wrong fetching the data." } ! []
@@ -93,7 +93,7 @@ update msg model =
             { model | userId = Just uId } ! []
 
         PutUserEmail (Ok _) ->
-            { model | email = Nothing } ! []
+            { model | email = SubmittedEmail } ! []
 
         PutUserEmail (Err _) ->
             model ! []

--- a/web/elm/Update.elm
+++ b/web/elm/Update.elm
@@ -1,7 +1,7 @@
 module Update exposing (..)
 
 import Model exposing (..)
-import Data.UserInfo exposing (validatePostcode, validateEmail)
+import Data.UserInfo exposing (validatePostcode, validateEmail, emailToString)
 import Data.Answers exposing (handleAnswer)
 import Data.QuoteServiceWeightings exposing (setQuoteServiceWeightings)
 import Data.Web.Answers exposing (handlePostAnswers)
@@ -93,7 +93,7 @@ update msg model =
             { model | userId = Just uId } ! []
 
         PutUserEmail (Ok _) ->
-            { model | email = SubmittedEmail } ! []
+            { model | email = SubmittedEmail <| emailToString model.email } ! []
 
         PutUserEmail (Err _) ->
             model ! []

--- a/web/elm/Update.elm
+++ b/web/elm/Update.elm
@@ -1,7 +1,7 @@
 module Update exposing (..)
 
 import Model exposing (..)
-import Data.UserInfo exposing (validatePostcode)
+import Data.UserInfo exposing (validatePostcode, validateEmail)
 import Data.Answers exposing (handleAnswer)
 import Data.QuoteServiceWeightings exposing (setQuoteServiceWeightings)
 import Data.Web.Answers exposing (handlePostAnswers)
@@ -64,7 +64,7 @@ update msg model =
             { model | ageRange = Just ageRange } ! []
 
         SetEmail email ->
-            { model | email = ValidEmail email } ! []
+            { model | email = validateEmail email } ! []
 
         ReceiveQuoteServiceWeightings (Err _) ->
             { model | fetchErrorMessage = "Something went wrong fetching the data." } ! []

--- a/web/elm/Views/Services.elm
+++ b/web/elm/Views/Services.elm
@@ -6,6 +6,7 @@ import Html.Events exposing (..)
 import Helpers.Styles as Styles
 import Components.Logo exposing (..)
 import Model exposing (..)
+import Data.UserInfo exposing (isValidEmail)
 
 
 services : Model -> Html Msg
@@ -50,27 +51,35 @@ renderEmailForm model =
             div [] []
 
         ValidEmail email ->
-            emailForm email
+            emailForm model email
 
         NotEnteredEmail ->
-            emailForm ""
+            emailForm model ""
 
         InvalidEmail email ->
-            emailForm email
+            emailForm model email
 
         SubmittedEmail ->
             div [] []
 
 
-emailForm : String -> Html Msg
-emailForm email =
+emailForm : Model -> String -> Html Msg
+emailForm model email =
     div []
         [ h3 [ class "blue" ] [ text "If you'd like a copy of them for futute reference, please enter your email" ]
         , input [ onInput SetEmail, class (Styles.inputField ++ " mw5 center"), placeholder "put your email", value email ] []
-        , button
+        , (handleSubmitEmail model)
+        ]
+
+
+handleSubmitEmail : Model -> Html Msg
+handleSubmitEmail model =
+    if isValidEmail model then
+        button
             [ onClick SubmitEmail
             , autocomplete False
             , class (Styles.buttonBlue ++ " mt3")
             ]
-            [ text "submit" ]
-        ]
+            [ text "Submit" ]
+    else
+        button [ class Styles.buttonDisabled ] [ text "Submit" ]

--- a/web/elm/Views/Services.elm
+++ b/web/elm/Views/Services.elm
@@ -46,17 +46,31 @@ renderResultsLink model =
 renderEmailForm : Model -> Html Msg
 renderEmailForm model =
     case model.email of
-        Just email ->
+        RetrievedEmail email ->
             div [] []
 
-        Nothing ->
-            div []
-                [ h3 [ class "blue" ] [ text "If you'd like a copy of them for futute reference, please enter your email" ]
-                , input [ onInput SetEmail, class (Styles.inputField ++ " mw5 center"), placeholder "put your email", value <| Maybe.withDefault "" model.email ] []
-                , button
-                    [ onClick SubmitEmail
-                    , autocomplete False
-                    , class (Styles.buttonBlue ++ " mt3")
-                    ]
-                    [ text "submit" ]
-                ]
+        ValidEmail email ->
+            emailForm email
+
+        NotEnteredEmail ->
+            emailForm ""
+
+        InvalidEmail email ->
+            emailForm email
+
+        SubmittedEmail ->
+            div [] []
+
+
+emailForm : String -> Html Msg
+emailForm email =
+    div []
+        [ h3 [ class "blue" ] [ text "If you'd like a copy of them for futute reference, please enter your email" ]
+        , input [ onInput SetEmail, class (Styles.inputField ++ " mw5 center"), placeholder "put your email", value email ] []
+        , button
+            [ onClick SubmitEmail
+            , autocomplete False
+            , class (Styles.buttonBlue ++ " mt3")
+            ]
+            [ text "submit" ]
+        ]

--- a/web/elm/Views/Services.elm
+++ b/web/elm/Views/Services.elm
@@ -18,6 +18,7 @@ services model =
         , div [ class "mw7 center mv4" ]
             [ (renderResultsLink model)
             , (renderEmailForm model)
+            , (emailSubmitted model)
             ]
         ]
 
@@ -41,15 +42,12 @@ renderResultsLink model =
                 ]
 
         Nothing ->
-            div [] []
+            emptyDiv
 
 
 renderEmailForm : Model -> Html Msg
 renderEmailForm model =
     case model.email of
-        RetrievedEmail email ->
-            div [] []
-
         ValidEmail email ->
             emailForm model email
 
@@ -59,8 +57,8 @@ renderEmailForm model =
         InvalidEmail email ->
             emailForm model email
 
-        SubmittedEmail ->
-            div [] []
+        _ ->
+            emptyDiv
 
 
 emailForm : Model -> String -> Html Msg
@@ -74,7 +72,7 @@ emailForm model email =
 
 handleSubmitEmail : Model -> Html Msg
 handleSubmitEmail model =
-    if isValidEmail model then
+    if isValidEmail model.email then
         button
             [ onClick SubmitEmail
             , autocomplete False
@@ -83,3 +81,18 @@ handleSubmitEmail model =
             [ text "Submit" ]
     else
         button [ class Styles.buttonDisabled ] [ text "Submit" ]
+
+
+emailSubmitted : Model -> Html Msg
+emailSubmitted model =
+    case model.email of
+        SubmittedEmail email ->
+            h3 [ class "blue" ] [ text <| "Your results have been sent to " ++ email ]
+
+        _ ->
+            emptyDiv
+
+
+emptyDiv : Html Msg
+emptyDiv =
+    div [] []

--- a/web/elm/Views/Services.elm
+++ b/web/elm/Views/Services.elm
@@ -15,14 +15,8 @@ services model =
         , h2 [ class "blue mb4" ] [ text "Here you are, your tailored list of Parkinson's services" ]
         , div [ class "bg-blue pb6" ] (List.map renderService model.top3things)
         , div [ class "mw7 center mv4" ]
-            [ h3 [ class "blue" ] [ text "If you'd like a copy of your results for futute reference, please enter your email" ]
-            , input [ onInput SetEmail, class (Styles.inputField ++ " mw5 center"), placeholder "put your email", value <| Maybe.withDefault "" model.email ] []
-            , button
-                [ onClick SubmitEmail
-                , autocomplete False
-                , class (Styles.buttonBlue ++ " mt3")
-                ]
-                [ text "submit" ]
+            [ (renderResultsLink model)
+            , (renderEmailForm model)
             ]
         ]
 
@@ -34,3 +28,35 @@ renderService s =
         , p [] [ text s.body ]
         , button [ class Styles.buttonBlue ] [ text s.cta ]
         ]
+
+
+renderResultsLink : Model -> Html Msg
+renderResultsLink model =
+    case model.uuid of
+        Just uuid ->
+            div []
+                [ h3 [ class "blue" ] [ text "Your results will be accessible at the following URL" ]
+                , a [ class "blue", href <| "http://localhost:4000/#my-results/" ++ uuid ] [ text <| (++) "http://localhost:4000/#my-results/" <| Maybe.withDefault "" model.uuid ]
+                ]
+
+        Nothing ->
+            div [] []
+
+
+renderEmailForm : Model -> Html Msg
+renderEmailForm model =
+    case model.email of
+        Just email ->
+            div [] []
+
+        Nothing ->
+            div []
+                [ h3 [ class "blue" ] [ text "If you'd like a copy of them for futute reference, please enter your email" ]
+                , input [ onInput SetEmail, class (Styles.inputField ++ " mw5 center"), placeholder "put your email", value <| Maybe.withDefault "" model.email ] []
+                , button
+                    [ onClick SubmitEmail
+                    , autocomplete False
+                    , class (Styles.buttonBlue ++ " mt3")
+                    ]
+                    [ text "submit" ]
+                ]

--- a/web/elm/Views/UserInfo/Postcode.elm
+++ b/web/elm/Views/UserInfo/Postcode.elm
@@ -37,7 +37,7 @@ postcodeField model =
 
 handleNext : Model -> Html Msg
 handleNext model =
-    if isValidPostcode model then
+    if isValidPostcode model.postcode then
         button [ class Styles.buttonBlue, onClick <| SetView Age ] [ text "Next" ]
     else
         button [ class Styles.buttonDisabled ] [ text "Next" ]

--- a/web/views/answer_view.ex
+++ b/web/views/answer_view.ex
@@ -8,6 +8,7 @@ defmodule What3things.AnswerView do
   def render("answer.json", %{answer: answer}) do
     %{id: answer.id,
       answers: answer.answers,
-      user_id: answer.user_id}
+      user_id: answer.user_id,
+      uuid: answer.uuid}
   end
 end


### PR DESCRIPTION
* Display results URL on services view.
* Create email type.
* Only render results URL and email form on first visit to services page.
* Client side email validation.

Resolves #84